### PR TITLE
feat: add azure trace dataset

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1014,6 +1014,8 @@ def create_argument_parser():
         default=float("inf"),
         help="Number of requests per second. If this is inf, "
         "then all the requests are sent at time 0. "
+        "If this is -1, then request arrivals are sent following a "
+        "timestamp from the dataset."
         "Otherwise, we use Poisson process or gamma distribution "
         "to synthesize the request arrival times.",
     )

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -59,6 +59,7 @@ except ImportError:
 from benchmark_dataset import (
     AIMODataset,
     ASRDataset,
+    AzureDataset,
     BurstGPTDataset,
     ConversationDataset,
     CustomDataset,
@@ -676,6 +677,16 @@ def main(args: argparse.Namespace):
                 tokenizer=tokenizer,
                 return_prompt_formatted=True,
             )
+    elif args.dataset_name == "azure":
+        dataset = AzureDataset(
+            dataset_path=args.dataset_path,
+        )
+        input_requests = dataset.sample(
+            num_requests=args.num_prompts,
+            tokenizer=tokenizer,
+            start_time=args.azure_start_time,
+            end_time=args.azure_end_time,
+        )
 
     elif args.dataset_name == "hf":
         # all following datasets are implemented from the
@@ -930,7 +941,15 @@ def create_argument_parser():
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf", "custom"],
+        choices=[
+            "sharegpt",
+            "burstgpt",
+            "sonnet",
+            "random",
+            "hf",
+            "custom",
+            "azure",
+        ],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(
@@ -1182,7 +1201,19 @@ def create_argument_parser():
             "input_len * (1 + range_ratio)]."
         ),
     )
-
+    azure_group = parser.add_argument_group("azure dataset options")
+    azure_group.add_argument(
+        "--azure-start-time",
+        type=str,
+        default="2023-11-16 18:00:00",
+        help="start time of trace, used only for azure dataset.",
+    )
+    azure_group.add_argument(
+        "--azure-end-time",
+        type=str,
+        default="2023-11-16 20:00:00",
+        help="end time of trace, used only for azure dataset.",
+    )
     hf_group = parser.add_argument_group("hf dataset options")
     hf_group.add_argument(
         "--hf-subset", type=str, default=None, help="Subset of the HF dataset."


### PR DESCRIPTION
Azure AI service 에서 sampling 한 실제 ai application workloads 를 vLLM online serving benchmark 에서 평가할 수 있도록, benchmark_dataset.py에 class 를 추가합니다. 

## target workloads
- chat conversation
- code generation 

## dataset link

- [https://github.com/Azure/AzurePublicDataset/blob/master/AzureLLMInferenceDataset2023.md](https://github.com/Azure/AzurePublicDataset/blob/master/AzureLLMInferenceDataset2023.md)


## details 
- trace dataset에 포함된 input/output length 를 가져와서 평가할 수 있도록 dataset class 와 관련 argument를 추가합니다. 
- dataset 에서 제공하는 timestamp 와, vllm benchmark의 num_request 옵션을 같이 사용할 경우, request 갯수 조절하는 방법을 정해야 합니다. 우선 request 갯수가 초과될 경우  warning을 띄우고, dataset 갯수로 request 갯수 조정하게 변경했습니다.

- start_time, end_time으로 사용할 trace 구간을 조정할 수 있도록 argument 를 추가했습니다.
