### PR TITLE
Minor fixes to run benchmark w/o installing it

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -4,7 +4,7 @@
 
 # The version.py should be independent library, and we always import the
 # version library first.  Such assumption is critical for some customization.
-from .version import __version__, __version_tuple__  # isort:skip
+# from .version import __version__, __version_tuple__  # isort:skip
 
 import typing
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -886,7 +886,7 @@ def get_cutlass_pplx_moe_mm_data(expert_offsets: torch.Tensor,
     used in CUTLASS-based fused MoE.
 
     The function takes in expert_num_tokens (token count per expert) and
-    non_zero_expert_idxs (consecutive indices of experts with non-zero token 
+    non_zero_expert_idxs (consecutive indices of experts with non-zero token
     counts) and uses them to compute:
     - expert_offsets: Indices that mark at which token index each expert begins
                       its computation.
@@ -2028,7 +2028,7 @@ def hadacore_transform(x: torch.Tensor, inplace: bool = True) -> torch.Tensor:
 
     Note that sylvester hadamard transforms are also symmetric, which means that
     this function is also applies the (transpose <=> inverse) transform.
-    
+
     :param x: value to be transformed inplace
     :param inplace: modify value in place
     :return: value after transformation

--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -50,6 +50,7 @@ class DeviceConfig:
         return hash_str
 
     def __post_init__(self):
+        return  # to avoid device_type error
         if self.device == "auto":
             # Automated device type detection
             from vllm.platforms import current_platform

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -69,14 +69,14 @@ class KVEventBatch(EventBatch):
 class EventPublisher(ABC):
     """Lightweight publisher for EventBatch batches with data parallelism
     support.
-    
+
     In data parallel setups, each DP rank runs its own EventPublisher instance
     to avoid duplicate events and ensure proper event attribution:
-    
+
     - Each DP rank creates a separate publisher
     - Publishers automatically annotate events with their data_parallel_rank
     - This allows consumers to distinguish events from different DP ranks
-    
+
     The publisher is responsible for adding DP metadata since the scheduler
     operates independently of DP topology and shouldn't need DP awareness.
     """
@@ -299,16 +299,16 @@ class ZmqEventPublisher(EventPublisher):
     @staticmethod
     def offset_endpoint_port(endpoint: Optional[str],
                              data_parallel_rank: int) -> Optional[str]:
-        """Helper function to offset the port in an endpoint by 
+        """Helper function to offset the port in an endpoint by
             the data parallel rank.
 
         Args:
-            endpoint: The endpoint string 
+            endpoint: The endpoint string
                 (e.g., "tcp://*:5557" or "inproc://cache")
             data_parallel_rank: The data parallel rank to offset by
 
         Returns:
-            The endpoint with the port offset by data_parallel_rank 
+            The endpoint with the port offset by data_parallel_rank
                 or suffix appended
         """
         # Do nothing if input is None or data_parallel_rank is 0

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -117,7 +117,7 @@ def get_kv_connector_cache_layout():
 
 
 class KVOutputAggregator:
-    """Utility class to aggregate the output of all workers into a single 
+    """Utility class to aggregate the output of all workers into a single
     output corresponding to Rank 0 for scheduler."""
 
     def __init__(self, world_size: int):

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -19,11 +19,11 @@ def main():
     from vllm.utils import FlexibleArgumentParser
 
     CMD_MODULES = [
-        vllm.entrypoints.cli.openai,
-        vllm.entrypoints.cli.serve,
+        # vllm.entrypoints.cli.openai,
+        # vllm.entrypoints.cli.serve,
         vllm.entrypoints.cli.benchmark.main,
-        vllm.entrypoints.cli.collect_env,
-        vllm.entrypoints.cli.run_batch,
+        # vllm.entrypoints.cli.collect_env,
+        # vllm.entrypoints.cli.run_batch,
     ]
 
     cli_env_setup()
@@ -36,7 +36,7 @@ def main():
         '-v',
         '--version',
         action='version',
-        version=importlib.metadata.version('vllm'),
+        version='version N/A',
     )
     subparsers = parser.add_subparsers(required=False, dest="subparser")
     cmds = {}

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -10,17 +10,17 @@ import uvloop
 import vllm
 import vllm.envs as envs
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.api_server import (run_server, run_server_worker,
-                                                setup_server)
+# from vllm.entrypoints.openai.api_server import (run_server, run_server_worker,
+#                                                 setup_server)
 from vllm.entrypoints.openai.cli_args import (make_arg_parser,
                                               validate_parsed_serve_args)
 from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
-from vllm.usage.usage_lib import UsageContext
+# from vllm.usage.usage_lib import UsageContext
 from vllm.utils import (FlexibleArgumentParser, decorate_logs, get_tcp_uri,
                         set_process_title)
-from vllm.v1.engine.core import EngineCoreProc
-from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
+# from vllm.v1.engine.core import EngineCoreProc
+# from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
 from vllm.v1.utils import (APIServerProcessManager,

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -45,13 +45,13 @@ class RenderConfig:
 class BaseRenderer(ABC):
     """
     Base class for unified input processing and rendering.
-    
+
     The Renderer serves as a unified input processor that consolidates
     tokenization, chat template formatting, and multimodal input handling
     into a single component.
     It converts high-level API requests (OpenAI-style JSON) into token IDs and
     multimodal features ready for engine consumption.
-    
+
     Key responsibilities:
     - Convert text prompts to token sequences with proper special tokens
     - Apply chat templates and format conversations
@@ -90,7 +90,7 @@ class BaseRenderer(ABC):
                 - ``list[int]``: Single pre-tokenized sequence.
                 - ``list[list[int]]``: Batch of pre-tokenized sequences.
             config: Render configuration controlling how prompts are prepared
-                (e.g., tokenization and length handling). 
+                (e.g., tokenization and length handling).
 
         Returns:
             list[EngineTokensPrompt]: Engine-ready token prompts.
@@ -122,7 +122,7 @@ class BaseRenderer(ABC):
             prompt_embeds: Base64-encoded bytes (or list thereof) containing a
                 torch-saved tensor to be used as prompt embeddings.
             config: Render configuration controlling how prompts are prepared
-                (e.g., tokenization and length handling). 
+                (e.g., tokenization and length handling).
 
         Returns:
             list[Union[EngineTokensPrompt, EngineEmbedsPrompt]]:
@@ -192,7 +192,7 @@ class CompletionRenderer(BaseRenderer):
         config: "RenderConfig",
     ) -> list[EngineTokensPrompt]:
         """Implementation of prompt rendering for completion-style requests.
-        
+
         Uses async tokenizer pooling for improved performance. See base class
         for detailed parameter documentation.
         """

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -12,7 +12,7 @@ from typing_extensions import TypeVar, deprecated
 
 import vllm.platforms
 from vllm.config import VllmConfig
-from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
+# from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.sequence import ExecuteModelRequest
@@ -30,7 +30,7 @@ class ExecutorBase(ABC):
     """Base class for all executors.
 
     An executor is responsible for executing the model on one device,
-    or it can be a distributed executor 
+    or it can be a distributed executor
     that can execute the model on multiple devices.
     """
 
@@ -83,7 +83,7 @@ class ExecutorBase(ABC):
 
         Returns:
             A list containing the results from each worker.
-        
+
         Note:
             It is recommended to use this API to only pass control messages,
             and set up data-plane communication to pass data.
@@ -100,7 +100,7 @@ class ExecutorBase(ABC):
 
         Returns a tuple `(num_gpu_blocks, num_cpu_blocks)`, where
         `num_gpu_blocks` are blocks that are "active" on the device and can be
-        appended to. 
+        appended to.
         `num_cpu_blocks` refers to "swapped" blocks in CPU memory and cannot be
         appended to.
         """
@@ -327,7 +327,7 @@ class DistributedExecutorBase(ExecutorBase):
                 run only in the remote TP workers, not the driver worker.
                 It will also be run asynchronously and return a list of futures
                 rather than blocking on the results.
-        
+
         # TODO: simplify and merge with collective_rpc
         """
         raise NotImplementedError

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional
 
 import torch
 
-from vllm import _custom_ops as ops
+# from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils import direct_register_custom_op
@@ -57,10 +57,10 @@ def apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
     """
     Applies penalties in place to the logits tensor
     logits : The input logits tensor of shape [num_seqs, vocab_size]
-    prompt_tokens_tensor: A tensor containing the prompt tokens. The prompts 
-        are padded to the maximum prompt length within the batch using 
-        `vocab_size` as the padding value. The value `vocab_size` is used 
-        for padding because it does not correspond to any valid token ID 
+    prompt_tokens_tensor: A tensor containing the prompt tokens. The prompts
+        are padded to the maximum prompt length within the batch using
+        `vocab_size` as the padding value. The value `vocab_size` is used
+        for padding because it does not correspond to any valid token ID
         in the vocabulary.
     output_tokens_tensor: The output tokens tensor.
     presence_penalties: The presence penalties of shape (num_seqs, )

--- a/vllm/multimodal/image.py
+++ b/vllm/multimodal/image.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Union
 
-import pybase64
+# import pybase64
 import torch
 from PIL import Image
 

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -274,7 +274,7 @@ class MultiModalProfiler(Generic[_I]):
 
         `<im_start> [IMG] [IMG] [IMG] <row_break> [IMG] [IMG] [IMG] <im_end>`
         Returns 9, even when the number of image embeddings is 6.
-        
+
         This is important to take into account when profiling and
         initializing the encoder cache size.
         """

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -19,15 +19,16 @@ def vllm_version_matches_substr(substr: str) -> bool:
     """
     Check to see if the vLLM version matches a substring.
     """
-    from importlib.metadata import PackageNotFoundError, version
-    try:
-        vllm_version = version("vllm")
-    except PackageNotFoundError as e:
-        logger.warning(
-            "The vLLM package was not found, so its version could not be "
-            "inspected. This may cause platform detection to fail.")
-        raise e
-    return substr in vllm_version
+    return True
+    # from importlib.metadata import PackageNotFoundError, version
+    # try:
+    #     vllm_version = version("vllm")
+    # except PackageNotFoundError as e:
+    #     logger.warning(
+    #         "The vLLM package was not found, so its version could not be "
+    #         "inspected. This may cause platform detection to fail.")
+    #     raise e
+    # return substr in vllm_version
 
 
 def tpu_platform_plugin() -> Optional[str]:

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -13,7 +13,7 @@ from threading import Thread
 from typing import Any, Optional, Union
 from uuid import uuid4
 
-import cpuinfo
+# import cpuinfo
 import psutil
 import requests
 import torch

--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -53,13 +53,13 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import cachetools
-import cbor2
-import cloudpickle
+# import cbor2
+# import cloudpickle
 import numpy as np
 import numpy.typing as npt
 import psutil
 import regex as re
-import setproctitle
+# import setproctitle
 import torch
 import torch.types
 import yaml
@@ -1388,8 +1388,8 @@ def find_nccl_library() -> str:
 def find_nccl_include_paths() -> Optional[list[str]]:
     """
     We either use the nccl.h specified by the `VLLM_NCCL_INCLUDE_PATH`
-    environment variable, or we find the library file brought by 
-    nvidia-nccl-cuXX. load_inline by default uses 
+    environment variable, or we find the library file brought by
+    nvidia-nccl-cuXX. load_inline by default uses
     torch.utils.cpp_extension.include_paths
     """
     paths: list[str] = []

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -9,7 +9,7 @@ from inspect import isclass
 from types import FunctionType
 from typing import Any, Callable, Optional, Union
 
-import cloudpickle
+# import cloudpickle
 import msgspec
 import numpy as np
 import torch
@@ -101,7 +101,7 @@ class MsgpackEncoder:
     Note that unlike vanilla `msgspec` Encoders, this interface is generally
     not thread-safe when encoding tensors / numpy arrays.
 
-    By default, arrays below 256B are serialized inline Larger will get sent 
+    By default, arrays below 256B are serialized inline Larger will get sent
     via dedicated messages. Note that this is a per-tensor limit.
     """
 

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -12,7 +12,7 @@ import numpy as np
 import regex as re
 import torch
 from cachetools import LRUCache
-from diskcache import Cache
+# from diskcache import Cache
 
 import vllm.envs as envs
 from vllm.logger import init_logger

--- a/vllm/version.py
+++ b/vllm/version.py
@@ -4,11 +4,11 @@
 try:
     from ._version import __version__, __version_tuple__
 except Exception as e:
-    import warnings
+    # import warnings
 
-    warnings.warn(f"Failed to read commit hash:\n{e}",
-                  RuntimeWarning,
-                  stacklevel=2)
+    # warnings.warn(f"Failed to read commit hash:\n{e}",
+    #               RuntimeWarning,
+    #               stacklevel=2)
 
     __version__ = "dev"
     __version_tuple__ = (0, 0, __version__)

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -5,7 +5,7 @@ import os
 from typing import (Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar,
                     Union)
 
-import cloudpickle
+# import cloudpickle
 import torch.nn as nn
 
 from vllm.config import VllmConfig, set_current_vllm_config


### PR DESCRIPTION
benchmark_serving.py 대신 vllm subcommand 로 들어가면서 vllm installation 없이 실행하기 위한 코드 수정들이 바뀌었습니다.
vllm installation 없이 벤치마크를 수행할 수 있도록 필요없는 import 들을 제거합니다.

### test 방법

vllm 설치 없이 furiosa-llm 설치 & furiosa-runtime/scripts/requirements.txt 만 설치한 상태에서
`python -m vllm.entrypoints.cli.main bench serve --help` 명령 성공