### PR TITLE
Fix multi turn benchmark

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -412,9 +412,6 @@ async def send_turn(
         # No reference assistant answer in the dataset for this user prompt;
         # can't derive token limits, so remove the dataset-derived defaults
         # and let the model generate freely.
-        if min_tokens == NUM_TOKENS_FROM_DATASET:
-            min_tokens = None
-
         if max_tokens == NUM_TOKENS_FROM_DATASET:
             max_tokens = None
 

--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -408,6 +408,15 @@ async def send_turn(
 
         if max_tokens == NUM_TOKENS_FROM_DATASET:
             max_tokens = max(1, answer_num_tokens)
+    else:
+        # No reference assistant answer in the dataset for this user prompt;
+        # can't derive token limits, so remove the dataset-derived defaults
+        # and let the model generate freely.
+        if min_tokens == NUM_TOKENS_FROM_DATASET:
+            min_tokens = None
+
+        if max_tokens == NUM_TOKENS_FROM_DATASET:
+            max_tokens = None
 
     # Send the current conversation to LLM and get a response
     response: ServerResponse = await send_request(
@@ -661,7 +670,7 @@ async def client_main(
             turns_count[conv_id] += 1
             current_turn = turns_count[conv_id]
 
-            assert current_turn < len(messages), (
+            assert current_turn <= len(messages), (
                 f"Turn number {current_turn} is invalid for conversation ID {conv_id}"
                 f" that has only {len(messages)} messages"
             )


### PR DESCRIPTION
## Purpose

- [slack thread for context](https://furiosa-ai.slack.com/archives/C07SP1PKCL9/p1770716636369289?thread_ts=1770703578.739249&cid=C07SP1PKCL9)
- Some chat logs within the ShareGPT dataset end with a user prompt without a following assistant prompt, sometimes having the user prompt only without any assistant responses. This causes assertions and safeguards within the current code to make certain clients fail unsafely without reporting their metrics, making the entire benchmark broken upon completion.
  - fixed incorrect assertion causing runtime errors for certain clients
  - added safeguard for certain sharegpt data missing an assistant response

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

